### PR TITLE
Add presigned URL uploads and S3 file cleanup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -136,7 +136,15 @@
       "Bash(lsof:*)",
       "Bash(xargs kill:*)",
       "Bash(kill:*)",
-      "Skill(create-pr)"
+      "Skill(create-pr)",
+      "Bash(for thread_id in PRRT_kwDOC-qnps5nZ3QH PRRT_kwDOC-qnps5nZ3QP PRRT_kwDOC-qnps5nZ3QU PRRT_kwDOC-qnps5nZ3Qc PRRT_kwDOC-qnps5nZ3Qi)",
+      "Bash(do)",
+      "Bash(done)",
+      "Bash(git fetch:*)",
+      "Bash(heroku logs:*)",
+      "Bash(command -v:*)",
+      "Bash(git rebase:*)",
+      "Bash(gh pr close:*)"
     ],
     "deny": [],
     "ask": []

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/FoundryMapsAdmin.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/FoundryMapsAdmin.tsx
@@ -1142,10 +1142,7 @@ const FoundryMapsAdmin: React.FC = () => {
                           : 'Complete!'}
                   </div>
                   <div className={styles.progressBar}>
-                    <div
-                      className={styles.progressFill}
-                      style={{ width: `${uploadProgress}%` }}
-                    />
+                    <div className={styles.progressFill} style={{ width: `${uploadProgress}%` }} />
                   </div>
                   <div className={styles.progressPercent}>{uploadProgress}%</div>
                 </div>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/foundry-maps-admin.module.scss
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/foundry-maps-admin.module.scss
@@ -623,6 +623,46 @@
   padding: $spacer * 1.5;
 }
 
+// Progress Bar Styles
+.progressContainer {
+  background-color: color.adjust($background-med, $lightness: 3%);
+  border: $border-width solid color.adjust($ash, $lightness: 50%);
+  border-radius: $border-radius;
+  padding: $spacer * 1.5;
+}
+
+.progressLabel {
+  color: $primary-dark;
+  font-family: $font-family-sans-serif;
+  font-size: $font-size-base;
+  font-weight: 600;
+  margin-bottom: $spacer * 0.75;
+  text-align: center;
+}
+
+.progressBar {
+  background-color: $gray-200;
+  border-radius: $border-radius;
+  height: 24px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.progressFill {
+  background: linear-gradient(90deg, $cobalt, color.adjust($cobalt, $lightness: 15%));
+  border-radius: $border-radius;
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.progressPercent {
+  color: $gray-700;
+  font-family: $font-family-sans-serif;
+  font-size: $font-size-sm;
+  margin-top: $spacer * 0.5;
+  text-align: center;
+}
+
 .formButtons {
   display: flex;
   gap: $spacer;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Rails.application.routes.draw do
       post '/maps/:id/upload_chunk', to: 'foundry_maps#upload_chunk'
       post '/maps/:id/finalize_upload', to: 'foundry_maps#finalize_upload'
       post '/maps/:id/upload_thumbnail', to: 'foundry_maps#upload_thumbnail'
+      get '/maps/:id/presign_upload', to: 'foundry_maps#presign_upload'
+      post '/maps/:id/process_s3_upload', to: 'foundry_maps#process_s3_upload'
       post '/maps/upload_image', to: 'foundry_maps#upload_image'
       delete '/maps/:id/files/:file_id', to: 'foundry_maps#delete_file'
       resources :foundry_maps, path: 'maps', except: %i[new edit], constraints: { format: 'json' }


### PR DESCRIPTION
## Summary

- Replace chunked uploads with presigned URL direct-to-S3 uploads for faster file transfers (bypasses Cloudflare/Heroku proxy)
- Add progress bar UI to show upload status instead of spinner
- Delete old S3 files when new package is uploaded (replaces existing files)
- Delete all S3 files and thumbnail when map is deleted

## Changes

### Backend
- Add `presign_upload` endpoint to generate presigned PUT URLs for direct S3 upload
- Add `process_s3_upload` endpoint to process files after S3 upload completes
- Add `delete_map_files_from_s3` helper to batch delete S3 files
- Add `delete_thumbnail_from_s3` helper to delete thumbnails
- Update `upload_package` to delete old files before processing new ones
- Update `destroy` to delete all S3 files when map is deleted

### Frontend
- Replace `uploadFileInChunks` with `uploadViaPresignedUrl`
- Add progress bar with status labels (Preparing, Uploading to S3, Processing)
- Remove unused `GiLinkedRings` import

## Test plan

- [ ] Upload a new map package and verify it uploads quickly
- [ ] Re-upload a package to an existing map and verify old files are deleted
- [ ] Delete a map and verify S3 files are cleaned up
- [ ] Verify progress bar shows correct status during upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)