### PR TITLE
Add Foundry module stats admin page

### DIFF
--- a/app/controllers/admin/v1/foundry_module_stats_controller.rb
+++ b/app/controllers/admin/v1/foundry_module_stats_controller.rb
@@ -9,7 +9,7 @@ module Admin
       def index
         authorize :foundry_module_stats, :index?
 
-        Rails.cache.delete(CACHE_KEY) if params[:refresh].present?
+        Rails.cache.delete(CACHE_KEY) if ActiveModel::Type::Boolean.new.cast(params[:refresh])
 
         cached = Rails.cache.read(CACHE_KEY)
         if cached

--- a/app/controllers/admin/v1/foundry_module_stats_controller.rb
+++ b/app/controllers/admin/v1/foundry_module_stats_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    class FoundryModuleStatsController < SecuredController
+      CACHE_KEY = 'foundry_module_stats/v1'
+      CACHE_TTL = 5.minutes
+
+      def index
+        authorize :foundry_module_stats, :index?
+
+        Rails.cache.delete(CACHE_KEY) if params[:refresh].present?
+
+        stats = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) do
+          FoundryModuleStatsFetcher.new.call
+        end
+
+        render json: stats
+      end
+    end
+  end
+end

--- a/app/controllers/admin/v1/foundry_module_stats_controller.rb
+++ b/app/controllers/admin/v1/foundry_module_stats_controller.rb
@@ -3,17 +3,26 @@
 module Admin
   module V1
     class FoundryModuleStatsController < SecuredController
-      CACHE_KEY = 'foundry_module_stats/v1'
-      CACHE_TTL = 5.minutes
+      CACHE_KEY = 'foundry_module_stats/v2'
+      CACHE_TTL = 15.minutes
 
       def index
         authorize :foundry_module_stats, :index?
 
         Rails.cache.delete(CACHE_KEY) if params[:refresh].present?
 
-        stats = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) do
-          FoundryModuleStatsFetcher.new.call
+        cached = Rails.cache.read(CACHE_KEY)
+        if cached
+          render json: cached
+          return
         end
+
+        stats = FoundryModuleStatsFetcher.new.call
+
+        # Don't poison the cache with a rate-limited response — return it
+        # live to the caller so the next request can retry once GitHub's
+        # bucket refills.
+        Rails.cache.write(CACHE_KEY, stats, expires_in: CACHE_TTL) unless stats[:rate_limited]
 
         render json: stats
       end

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/DataTable/DataTable.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/DataTable/DataTable.tsx
@@ -192,10 +192,13 @@ const DataTable = <T extends object = Record<string, unknown>>({
         })}
       >
         <thead>
-          {dataTable.headerGroups.map((headerGroup) => {
-            const { key: _headerKey, ...headerGroupProps } = headerGroup.getHeaderGroupProps();
+          {dataTable.headerGroups.map((headerGroup, headerGroupIndex) => {
+            const { key: headerKey, ...headerGroupProps } = headerGroup.getHeaderGroupProps();
             return (
-              <tr key={headerGroup.id} {...headerGroupProps}>
+              <tr
+                key={(headerKey as React.Key | undefined) ?? `header-group-${headerGroupIndex}`}
+                {...headerGroupProps}
+              >
                 {headerGroup.headers.map((column) => {
                   const columnWithSorting = column as unknown as ColumnWithSorting<object>;
                   const { key: _columnKey, ...columnProps } = columnWithSorting.getHeaderProps(

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.styles.ts
@@ -112,6 +112,15 @@ export const SiteTitle = styled.h3`
   text-shadow: 1px 1px ${({ theme }) => theme.colors.black};
 `;
 
+export const SiteVersion = styled.div`
+  color: ${({ theme }) => adjustLightness(theme.colors.danger, 30)};
+  font-family: ${({ theme }) => theme.fonts.monospace};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  opacity: 0.85;
+`;
+
 export const Logo = styled.img`
   max-height: 12rem;
 `;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.styles.ts
@@ -112,13 +112,18 @@ export const SiteTitle = styled.h3`
   text-shadow: 1px 1px ${({ theme }) => theme.colors.black};
 `;
 
-export const SiteVersion = styled.div`
-  color: ${({ theme }) => adjustLightness(theme.colors.danger, 30)};
-  font-family: ${({ theme }) => theme.fonts.monospace};
+export const Copyright = styled.div`
+  border-top: 1px solid ${({ theme }) => adjustLightness(theme.colors.darkRed, 10)};
+  color: ${({ theme }) => adjustLightness(theme.colors.danger, 35)};
+  font-family: ${({ theme }) => theme.fonts.sansSerif};
   font-size: ${({ theme }) => theme.fontSizes.xs};
   letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
-  opacity: 0.85;
+  margin-top: 1rem;
+  opacity: 0.8;
+  padding-top: 0.75rem;
+  position: relative;
+  text-align: center;
+  z-index: 101;
 `;
 
 export const Logo = styled.img`

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.tsx
@@ -20,8 +20,8 @@ import {
   PatreonText,
   FooterLink,
   SiteTitle,
-  SiteVersion,
   Logo,
+  Copyright,
 } from './Footer.styles';
 
 const PATREON_URL =
@@ -35,7 +35,6 @@ const Footer = (_props: { user?: User }) => {
       <Content>
         <Left>
           <SiteTitle>Dungeon Master GURU</SiteTitle>
-          <SiteVersion>v{packageJson.version}</SiteVersion>
           <Logo as={DndLogo} />
         </Left>
         <Center>
@@ -67,6 +66,9 @@ const Footer = (_props: { user?: User }) => {
           </Nav>
         </Right>
       </Content>
+      <Copyright>
+        © {new Date().getFullYear()} Jess Hendricks · v{packageJson.version}
+      </Copyright>
     </FooterWrapper>
   );
 };

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import DndLogo from '../HeroBanner/DMLogo';
 import { User } from '@auth0/auth0-react';
 import { useSidebar } from '../../contexts/SidebarContext';
 
+import packageJson from '../../../../../../package.json';
 import footerBg from './FooterBackground.jpg';
 import patreonBanner from './PatreonBanner.png';
 
@@ -19,6 +20,7 @@ import {
   PatreonText,
   FooterLink,
   SiteTitle,
+  SiteVersion,
   Logo,
 } from './Footer.styles';
 
@@ -33,6 +35,7 @@ const Footer = (_props: { user?: User }) => {
       <Content>
         <Left>
           <SiteTitle>Dungeon Master GURU</SiteTitle>
+          <SiteVersion>v{packageJson.version}</SiteVersion>
           <Logo as={DndLogo} />
         </Left>
         <Center>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/components/SideBar/SideBar.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/components/SideBar/SideBar.tsx
@@ -217,15 +217,19 @@ const SideBar = (props: {
   }, [location.pathname]);
 
   const handleLogout = () => {
-    void getAccessTokenSilently()
-      .then((token) => {
-        logOutUser(token);
-        document.cookie =
-          '_dungeon_master_screen_online_session=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-        void logout({ logoutParams: { returnTo: window.location.origin } });
-      })
+    // Always clear local session state, even if Auth0's silent token fetch fails
+    // (e.g. expired refresh token). Otherwise a stale token would trap the user
+    // in a logged-in-but-broken state with no way to log out from the UI.
+    document.cookie =
+      '_dungeon_master_screen_online_session=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+
+    getAccessTokenSilently()
+      .then((token) => logOutUser(token))
       .catch((err) => {
-        console.error(err);
+        console.warn('Silent token fetch failed during logout, proceeding anyway:', err);
+      })
+      .finally(() => {
+        void logout({ logoutParams: { returnTo: window.location.origin } });
       });
   };
 

--- a/app/javascript/bundles/DungeonMasterCampaignManager/navigation/DMRoutes.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/navigation/DMRoutes.tsx
@@ -27,6 +27,7 @@ import EditWidgetPage from '../pages/admin-dashboard/EditWidgetPage';
 import SearchResults from '../pages/search-results/SearchResults';
 import PrivacyPolicy from '../pages/privacy-policy/PrivacyPolicy';
 import FoundryMapsAdmin from '../pages/FoundryMapsAdmin';
+import FoundryModuleStatsPage from '../pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage';
 import { ItemType } from '../pages/items/use-data';
 
 type ResolverProps = Record<string, unknown>;
@@ -159,6 +160,10 @@ const DMRoutes = (props: ResolverProps) => {
       <Route
         path="/app/admin-dashboard/foundry-maps"
         element={<ProtectedRoute as={FoundryMapsAdmin} requireAdmin={true} {...props} />}
+      />
+      <Route
+        path="/app/admin-dashboard/foundry-module-stats"
+        element={<ProtectedRoute as={FoundryModuleStatsPage} requireAdmin={true} {...props} />}
       />
       <Route
         path="/app/user-dashboard"

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
@@ -50,11 +50,23 @@ export const InfoContainer = styled.div`
 `;
 
 export const InfoFlex1 = styled.div`
+  display: flex;
   flex: 1;
+  flex-direction: column;
+
+  > * {
+    flex: 1;
+  }
 `;
 
 export const InfoFlex2 = styled.div`
+  display: flex;
   flex: 2;
+  flex-direction: column;
+
+  > * {
+    flex: 1;
+  }
 `;
 
 export const EditButton = styled.span`

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
@@ -31,9 +31,14 @@ export const ActionTypeContainer = styled.div`
 
 export const InfoContainer = styled.div`
   align-items: stretch;
-  display: grid;
-  grid-gap: ${({ theme }) => theme.spacing.spacer};
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.spacing.spacer};
+  margin-bottom: ${({ theme }) => theme.spacing.spacer};
+
+  > * {
+    min-width: 240px;
+  }
 
   p {
     color: ${({ theme }) => theme.colors.primaryDark};
@@ -42,6 +47,14 @@ export const InfoContainer = styled.div`
     grid-template-columns: 2fr 1fr;
     max-width: 25rem;
   }
+`;
+
+export const InfoFlex1 = styled.div`
+  flex: 1;
+`;
+
+export const InfoFlex2 = styled.div`
+  flex: 2;
 `;
 
 export const EditButton = styled.span`

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.styles.ts
@@ -30,9 +30,10 @@ export const ActionTypeContainer = styled.div`
 `;
 
 export const InfoContainer = styled.div`
+  align-items: stretch;
   display: grid;
   grid-gap: ${({ theme }) => theme.spacing.spacer};
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 
   p {
     color: ${({ theme }) => theme.colors.primaryDark};

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.tsx
@@ -15,9 +15,7 @@ import Frame from '../../components/Frame/Frame';
 import Button from '../../components/Button/Button';
 import { Colors } from '../../utilities/enums';
 
-import packageJson from '../../../../../../package.json';
-
-import { Wrapper, Section, InfoContainer } from './AdminDashboard.styles';
+import { Wrapper, Section, InfoContainer, InfoFlex1, InfoFlex2 } from './AdminDashboard.styles';
 import { RootState, AppDispatch } from '../../store/store';
 
 const AdminDashboard = (props: {
@@ -42,23 +40,22 @@ const AdminDashboard = (props: {
         <Section>
           <h2>Site Statistics</h2>
           <InfoContainer>
-            <Frame style={{ width: '100%', height: '100%' }} title={'Info'}>
-              <p>
-                <strong>Users:</strong> {userCount}
-              </p>
-              <p>
-                <strong>Custom Actions:</strong> {actionCount}
-              </p>
-              <p>
-                <strong>Custom NPCs:</strong> {npcCount}
-              </p>
-            </Frame>
-            <Frame style={{ width: '100%', height: '100%' }} title={'Site'}>
-              <p>
-                <strong>Version:</strong> {packageJson.version}
-              </p>
-            </Frame>
-            <FoundryStatsPanel />
+            <InfoFlex1>
+              <Frame style={{ width: '100%', height: '100%' }} title={'Info'}>
+                <p>
+                  <strong>Users:</strong> {userCount}
+                </p>
+                <p>
+                  <strong>Custom Actions:</strong> {actionCount}
+                </p>
+                <p>
+                  <strong>Custom NPCs:</strong> {npcCount}
+                </p>
+              </Frame>
+            </InfoFlex1>
+            <InfoFlex2>
+              <FoundryStatsPanel />
+            </InfoFlex2>
           </InfoContainer>
           <Section>
             <h3>Users</h3>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/AdminDashboard.tsx
@@ -5,6 +5,7 @@ import MonstersTable from '../monsters/MonstersTable';
 import UsersTable from './components/UsersTable';
 import { GiBarbute, GiBlacksmith } from 'react-icons/gi';
 import { FaMap } from 'react-icons/fa';
+import FoundryStatsPanel from './foundry-module-stats/components/FoundryStatsPanel';
 import { useNavigate } from 'react-router-dom';
 import ActionsTable from './components/ActionsTable';
 import WidgetsTable from './components/WidgetsTable';
@@ -57,6 +58,7 @@ const AdminDashboard = (props: {
                 <strong>Version:</strong> {packageJson.version}
               </p>
             </Frame>
+            <FoundryStatsPanel />
           </InfoContainer>
           <Section>
             <h3>Users</h3>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.styles.ts
@@ -1,0 +1,379 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  max-width: 1100px;
+  margin: 0 auto;
+`;
+
+export const Section = styled.section`
+  padding: ${({ theme }) => theme.spacing.spacer} 0;
+  width: 100%;
+`;
+
+export const RefreshBar = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.spacing.spacer};
+  justify-content: space-between;
+  margin-bottom: calc(${({ theme }) => theme.spacing.spacer} * 0.5);
+`;
+
+export const LastUpdated = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-family: ${({ theme }) => theme.fonts.serif};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-style: italic;
+`;
+
+export const SummaryGrid = styled.div`
+  display: grid;
+  gap: ${({ theme }) => theme.spacing.spacer};
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-bottom: ${({ theme }) => theme.spacing.spacer};
+`;
+
+export const SummaryCard = styled.div`
+  background: ${({ theme }) => theme.colors.cardBg};
+  border: 1px solid ${({ theme }) => theme.colors.borderColor};
+  border-top: 3px solid ${({ theme }) => theme.colors.gold};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  box-shadow: ${({ theme }) => theme.shadows.sm};
+  padding: ${({ theme }) => theme.spacing.spacer};
+  text-align: center;
+`;
+
+export const SummaryNumber = styled.div`
+  color: ${({ theme }) => theme.colors.primary};
+  font-family: ${({ theme }) => theme.fonts.draconis};
+  font-size: ${({ theme }) => theme.fontSizes['2xl']};
+  line-height: 1;
+`;
+
+export const SummaryNumberSmall = styled(SummaryNumber)`
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  padding-top: 0.3rem;
+`;
+
+export const SummaryLabel = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-family: ${({ theme }) => theme.fonts.sansSerif};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  letter-spacing: 0.1em;
+  margin-top: 0.4rem;
+  text-transform: uppercase;
+`;
+
+export const ChartWrap = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.spacing[4]};
+  justify-content: center;
+`;
+
+export const ChartCanvasWrap = styled.div`
+  flex-shrink: 0;
+  height: 240px;
+  width: 240px;
+`;
+
+export const ChartLegend = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  list-style: none;
+  margin: 0;
+  min-width: 220px;
+  padding: 0;
+`;
+
+export const LegendItem = styled.li`
+  align-items: center;
+  display: flex;
+  font-family: ${({ theme }) => theme.fonts.serif};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  gap: 0.6rem;
+`;
+
+export const LegendDot = styled.span<{ $color: string }>`
+  background: ${({ $color }) => $color};
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+  height: 12px;
+  width: 12px;
+`;
+
+export const LegendName = styled.span`
+  color: ${({ theme }) => theme.colors.bodyColor};
+  flex: 1;
+`;
+
+export const LegendCount = styled.span`
+  color: ${({ theme }) => theme.colors.primary};
+  font-weight: 600;
+`;
+
+export const LegendPct = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  margin-left: 0.25rem;
+`;
+
+export const ChartPlaceholder = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-style: italic;
+  padding: ${({ theme }) => theme.spacing[4]};
+  text-align: center;
+`;
+
+export const ModulesGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing[2]};
+`;
+
+export const ModuleCard = styled.div<{ $open: boolean }>`
+  background: ${({ theme }) => theme.colors.cardBg};
+  border: 1px solid ${({ $open, theme }) => ($open ? theme.colors.gold : theme.colors.borderColor)};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  box-shadow: ${({ theme }) => theme.shadows.sm};
+  overflow: hidden;
+  transition: border-color ${({ theme }) => theme.transitions.fast};
+`;
+
+export const ModuleHeaderButton = styled.button`
+  align-items: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  font-family: inherit;
+  gap: ${({ theme }) => theme.spacing.spacer};
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing[3]} ${({ theme }) => theme.spacing[4]};
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: rgba(201, 173, 106, 0.08);
+  }
+`;
+
+export const ModuleLeft = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1;
+  gap: 0.75rem;
+  min-width: 0;
+`;
+
+export const Chevron = styled.span<{ $open: boolean }>`
+  color: ${({ theme }) => theme.colors.secondary};
+  display: inline-block;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform ${({ theme }) => theme.transitions.fast};
+  width: 14px;
+`;
+
+export const ModuleInfo = styled.div`
+  min-width: 0;
+`;
+
+export const ModuleName = styled.div`
+  color: ${({ theme }) => theme.colors.primary};
+  font-family: ${({ theme }) => theme.fonts.mrEaves};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  letter-spacing: 0.02em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ModuleMeta = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+`;
+
+export const RepoLink = styled.a`
+  color: ${({ theme }) => theme.colors.cobalt};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-style: italic;
+  opacity: 0.8;
+  text-decoration: none;
+  transition: opacity ${({ theme }) => theme.transitions.fast};
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export const IssuesBadge = styled.a<{ $hasIssues: boolean }>`
+  align-items: center;
+  background: ${({ theme }) => theme.colors.gray100};
+  border: 1px solid
+    ${({ $hasIssues, theme }) => ($hasIssues ? theme.colors.danger : theme.colors.borderColor)};
+  border-radius: 2px;
+  color: ${({ $hasIssues, theme }) => ($hasIssues ? theme.colors.danger : theme.colors.textMuted)};
+  display: inline-flex;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  gap: 0.3rem;
+  padding: 0.1rem 0.5rem;
+  text-decoration: none;
+`;
+
+export const IssuesDot = styled.span`
+  background: currentColor;
+  border-radius: 50%;
+  height: 5px;
+  width: 5px;
+`;
+
+export const VersionCounts = styled.div`
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: ${({ theme }) => theme.spacing[4]};
+`;
+
+export const VersionRow = styled.div<{ $empty?: boolean }>`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+  opacity: ${({ $empty }) => ($empty ? 0.5 : 1)};
+`;
+
+export const VersionTag = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-family: ${({ theme }) => theme.fonts.sansSerif};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  letter-spacing: 0.1em;
+  margin-bottom: 0.3rem;
+  text-transform: uppercase;
+`;
+
+export const VersionNum = styled.span`
+  color: ${({ theme }) => theme.colors.cobalt};
+  font-family: ${({ theme }) => theme.fonts.monospace};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  margin-bottom: 0.25rem;
+`;
+
+export const VersionCount = styled.span`
+  color: ${({ theme }) => theme.colors.primary};
+  font-family: ${({ theme }) => theme.fonts.draconis};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+`;
+
+export const AccordionBody = styled.div<{ $open: boolean }>`
+  border-top: 1px solid ${({ theme, $open }) => ($open ? theme.colors.borderColor : 'transparent')};
+  display: ${({ $open }) => ($open ? 'block' : 'none')};
+`;
+
+export const ReleasesTable = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+
+  th {
+    background: ${({ theme }) => theme.colors.gray100};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.borderColor};
+    color: ${({ theme }) => theme.colors.textMuted};
+    font-family: ${({ theme }) => theme.fonts.sansSerif};
+    font-size: ${({ theme }) => theme.fontSizes.xs};
+    letter-spacing: 0.1em;
+    padding: 0.55rem ${({ theme }) => theme.spacing[4]};
+    text-align: left;
+    text-transform: uppercase;
+  }
+
+  th:last-child {
+    text-align: right;
+  }
+
+  td {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.borderColor};
+    font-size: ${({ theme }) => theme.fontSizes.sm};
+    padding: 0.6rem ${({ theme }) => theme.spacing[4]};
+  }
+
+  td:last-child {
+    text-align: right;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  tr.latest-row td {
+    background: rgba(201, 173, 106, 0.12);
+  }
+`;
+
+export const ReleaseTag = styled.span`
+  color: ${({ theme }) => theme.colors.cobalt};
+  font-family: ${({ theme }) => theme.fonts.monospace};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+export const LatestBadge = styled.span`
+  background: rgba(201, 173, 106, 0.2);
+  border: 1px solid ${({ theme }) => theme.colors.gold};
+  color: ${({ theme }) => theme.colors.primary};
+  font-family: ${({ theme }) => theme.fonts.sansSerif};
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.35rem;
+  text-transform: uppercase;
+`;
+
+export const DlBarWrap = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 0.7rem;
+  justify-content: flex-end;
+`;
+
+export const DlBarBg = styled.div`
+  background: ${({ theme }) => theme.colors.borderColor};
+  border-radius: 2px;
+  height: 4px;
+  overflow: hidden;
+  width: 80px;
+`;
+
+export const DlBarFill = styled.div<{ $pct: number }>`
+  background: linear-gradient(
+    90deg,
+    ${({ theme }) => theme.colors.secondary},
+    ${({ theme }) => theme.colors.gold}
+  );
+  height: 100%;
+  width: ${({ $pct }) => $pct}%;
+`;
+
+export const DlCount = styled.span`
+  color: ${({ theme }) => theme.colors.primary};
+  font-weight: 600;
+  min-width: 2rem;
+  text-align: right;
+`;
+
+export const NoReleases = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-style: italic;
+  padding: ${({ theme }) => theme.spacing[3]} ${({ theme }) => theme.spacing[4]};
+`;
+
+export const ErrorMsg = styled.div`
+  color: ${({ theme }) => theme.colors.danger};
+  font-style: italic;
+  padding: ${({ theme }) => theme.spacing[3]} ${({ theme }) => theme.spacing[4]};
+`;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.styles.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.styles.ts
@@ -143,30 +143,37 @@ export const ModuleCard = styled.div<{ $open: boolean }>`
   transition: border-color ${({ theme }) => theme.transitions.fast};
 `;
 
+export const ModuleHeaderRow = styled.div`
+  align-items: center;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.spacer};
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing[3]} ${({ theme }) => theme.spacing[4]};
+`;
+
+export const ModuleHeaderLeft = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+`;
+
 export const ModuleHeaderButton = styled.button`
   align-items: center;
   background: transparent;
   border: 0;
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   font-family: inherit;
-  gap: ${({ theme }) => theme.spacing.spacer};
-  justify-content: space-between;
-  padding: ${({ theme }) => theme.spacing[3]} ${({ theme }) => theme.spacing[4]};
+  gap: 0.75rem;
+  padding: 0.25rem 0;
   text-align: left;
-  width: 100%;
 
   &:hover {
     background: rgba(201, 173, 106, 0.08);
   }
-`;
-
-export const ModuleLeft = styled.div`
-  align-items: center;
-  display: flex;
-  flex: 1;
-  gap: 0.75rem;
-  min-width: 0;
 `;
 
 export const Chevron = styled.span<{ $open: boolean }>`
@@ -177,10 +184,6 @@ export const Chevron = styled.span<{ $open: boolean }>`
   transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
   transition: transform ${({ theme }) => theme.transitions.fast};
   width: 14px;
-`;
-
-export const ModuleInfo = styled.div`
-  min-width: 0;
 `;
 
 export const ModuleName = styled.div`

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
@@ -83,6 +83,12 @@ const FoundryModuleStatsPage: React.FC = () => {
             />
           </RefreshBar>
           {error && <ErrorMsg>Could not load stats: {error}</ErrorMsg>}
+          {data?.rate_limited && (
+            <ErrorMsg>
+              GitHub rate limit reached. Showing partial data — set GITHUB_TOKEN to lift the 60
+              req/hr cap.
+            </ErrorMsg>
+          )}
           {data && <SummaryBar modules={data.modules} />}
         </Section>
 

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import PageContainer from '../../../containers/PageContainer';
+import PageTitle from '../../../components/PageTitle/PageTitle';
+import Frame from '../../../components/Frame/Frame';
+import Button from '../../../components/Button/Button';
+import { Colors } from '../../../utilities/enums';
+import SummaryBar from './components/SummaryBar';
+import InstallDonut from './components/InstallDonut';
+import ModuleAccordion from './components/ModuleAccordion';
+import { FoundryModuleStatsResponse } from './types';
+import {
+  ChartPlaceholder,
+  ErrorMsg,
+  LastUpdated,
+  ModulesGrid,
+  RefreshBar,
+  Section,
+  Wrapper,
+} from './FoundryModuleStatsPage.styles';
+
+const ENDPOINT = '/v1/foundry-module-stats.json';
+
+const FoundryModuleStatsPage: React.FC = () => {
+  const { getAccessTokenSilently } = useAuth0();
+  const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (refresh = false) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = await getAccessTokenSilently();
+        const url = refresh ? `${ENDPOINT}?refresh=1` : ENDPOINT;
+        const response = await fetch(url, {
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const json = (await response.json()) as FoundryModuleStatsResponse;
+        setData(json);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load stats');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [getAccessTokenSilently],
+  );
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  const lastUpdated = data?.fetched_at
+    ? `Last updated: ${new Date(data.fetched_at).toLocaleString()}`
+    : '';
+
+  return (
+    <PageContainer
+      pageTitle="Foundry Module Stats"
+      description="Install statistics for Foundry VTT modules published on GitHub."
+    >
+      <PageTitle title="Foundry Module Stats" />
+      <Wrapper>
+        <Section>
+          <RefreshBar>
+            <LastUpdated>{lastUpdated}</LastUpdated>
+            <Button
+              color={Colors.primary}
+              title={loading ? 'Loading…' : 'Refresh'}
+              onClick={() => {
+                void load(true);
+              }}
+              disabled={loading}
+              isLoading={loading}
+            />
+          </RefreshBar>
+          {error && <ErrorMsg>Could not load stats: {error}</ErrorMsg>}
+          {data && <SummaryBar modules={data.modules} />}
+        </Section>
+
+        <Section>
+          <Frame title="Install Distribution — Latest Release">
+            {loading && !data ? (
+              <ChartPlaceholder>Loading chart…</ChartPlaceholder>
+            ) : data ? (
+              <InstallDonut modules={data.modules} />
+            ) : (
+              <ChartPlaceholder>No data yet.</ChartPlaceholder>
+            )}
+          </Frame>
+        </Section>
+
+        <Section>
+          <ModulesGrid>
+            {data?.modules.map((mod) => (
+              <ModuleAccordion key={mod.repo} module={mod} />
+            ))}
+          </ModulesGrid>
+        </Section>
+      </Wrapper>
+    </PageContainer>
+  );
+};
+
+export default FoundryModuleStatsPage;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
+import React from 'react';
 import PageContainer from '../../../containers/PageContainer';
 import PageTitle from '../../../components/PageTitle/PageTitle';
 import Frame from '../../../components/Frame/Frame';
@@ -8,7 +7,7 @@ import { Colors } from '../../../utilities/enums';
 import SummaryBar from './components/SummaryBar';
 import InstallDonut from './components/InstallDonut';
 import ModuleAccordion from './components/ModuleAccordion';
-import { FoundryModuleStatsResponse } from './types';
+import useFoundryModuleStats from './useFoundryModuleStats';
 import {
   ChartPlaceholder,
   ErrorMsg,
@@ -19,44 +18,8 @@ import {
   Wrapper,
 } from './FoundryModuleStatsPage.styles';
 
-const ENDPOINT = '/v1/foundry-module-stats.json';
-
 const FoundryModuleStatsPage: React.FC = () => {
-  const { getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(
-    async (refresh = false) => {
-      setLoading(true);
-      setError(null);
-      try {
-        const token = await getAccessTokenSilently();
-        const url = refresh ? `${ENDPOINT}?refresh=1` : ENDPOINT;
-        const response = await fetch(url, {
-          headers: {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        const json = (await response.json()) as FoundryModuleStatsResponse;
-        setData(json);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to load stats');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [getAccessTokenSilently],
-  );
-
-  useEffect(() => {
-    void load(false);
-  }, [load]);
+  const { data, loading, error, reload } = useFoundryModuleStats();
 
   const lastUpdated = data?.fetched_at
     ? `Last updated: ${new Date(data.fetched_at).toLocaleString()}`
@@ -75,9 +38,7 @@ const FoundryModuleStatsPage: React.FC = () => {
             <Button
               color={Colors.primary}
               title={loading ? 'Loading…' : 'Refresh'}
-              onClick={() => {
-                void load(true);
-              }}
+              onClick={reload}
               disabled={loading}
               isLoading={loading}
             />

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/DonutSvg.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/DonutSvg.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { ModuleStats } from '../types';
+
+// On-brand palette derived from theme accent colors. Stays distinct enough
+// for a 7-slice chart without leaving the parchment palette.
+export const DONUT_PALETTE = [
+  '#972c1d', // primary (dark red)
+  '#dd9529', // orange
+  '#7a853b', // green
+  '#2a50a1', // cobalt
+  '#7b469b', // iris
+  '#c9ad6a', // gold
+  '#507f62', // pine green
+];
+
+interface Props {
+  modules: ModuleStats[];
+  size?: number;
+}
+
+const polarToCartesian = (cx: number, cy: number, r: number, angleDeg: number) => {
+  const angleRad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + r * Math.cos(angleRad),
+    y: cy + r * Math.sin(angleRad),
+  };
+};
+
+const describeArc = (
+  cx: number,
+  cy: number,
+  rOuter: number,
+  rInner: number,
+  startAngle: number,
+  endAngle: number,
+) => {
+  const startOuter = polarToCartesian(cx, cy, rOuter, endAngle);
+  const endOuter = polarToCartesian(cx, cy, rOuter, startAngle);
+  const startInner = polarToCartesian(cx, cy, rInner, startAngle);
+  const endInner = polarToCartesian(cx, cy, rInner, endAngle);
+  const largeArc = endAngle - startAngle <= 180 ? '0' : '1';
+
+  return [
+    `M ${startOuter.x} ${startOuter.y}`,
+    `A ${rOuter} ${rOuter} 0 ${largeArc} 0 ${endOuter.x} ${endOuter.y}`,
+    `L ${startInner.x} ${startInner.y}`,
+    `A ${rInner} ${rInner} 0 ${largeArc} 1 ${endInner.x} ${endInner.y}`,
+    'Z',
+  ].join(' ');
+};
+
+// Pure SVG donut. The native <title> on each slice gives browser tooltips
+// on hover (no JS needed). Reused by InstallDonut (full layout with legend)
+// and FoundryStatsPanel (compact dashboard tile).
+const DonutSvg: React.FC<Props> = ({ modules, size = 220 }) => {
+  const active = modules.filter((m) => m.latest_installs > 0);
+  if (active.length === 0) return null;
+
+  const total = active.reduce((sum, m) => sum + m.latest_installs, 0);
+  const cx = 110;
+  const cy = 110;
+  const rOuter = 100;
+  const rInner = 58;
+
+  let cursor = 0;
+  const slices = active.map((mod, i) => {
+    const fraction = mod.latest_installs / total;
+    const sliceAngle = fraction * 360;
+    const startAngle = cursor;
+    const endAngle = cursor + sliceAngle;
+    cursor = endAngle;
+
+    const color = DONUT_PALETTE[i % DONUT_PALETTE.length];
+    const tooltip = `${mod.name}: ${mod.latest_installs.toLocaleString()} installs (${(
+      fraction * 100
+    ).toFixed(1)}%)`;
+
+    if (active.length === 1) {
+      return (
+        <g key={mod.repo} data-testid="donut-slice">
+          <circle cx={cx} cy={cy} r={rOuter} fill={color} />
+          <circle cx={cx} cy={cy} r={rInner} fill="#fdf1dc" />
+          <title>{`${mod.name}: ${mod.latest_installs.toLocaleString()} installs (100%)`}</title>
+        </g>
+      );
+    }
+
+    return (
+      <path
+        key={mod.repo}
+        data-testid="donut-slice"
+        d={describeArc(cx, cy, rOuter, rInner, startAngle, endAngle)}
+        fill={color}
+        stroke="#fdf1dc"
+        strokeWidth={2}
+      >
+        <title>{tooltip}</title>
+      </path>
+    );
+  });
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 220 220"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Install distribution by module"
+    >
+      {slices}
+    </svg>
+  );
+};
+
+export default DonutSvg;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Frame from '../../../../components/Frame/Frame';
 import Button from '../../../../components/Button/Button';
@@ -9,13 +9,14 @@ import useFoundryModuleStats from '../useFoundryModuleStats';
 
 const STATS_PATH = '/app/admin-dashboard/foundry-module-stats';
 
-const ClickableArea = styled.button`
-  background: transparent;
-  border: 0;
-  cursor: pointer;
+// styled(Link) — semantic anchor, valid HTML wrapper for the donut SVG and
+// legend (block-level content). Avoids the previous <button> that wrapped
+// block-level children, which was invalid HTML.
+const ClickableArea = styled(Link)`
+  color: inherit;
   display: block;
   padding: 0.25rem;
-  text-align: left;
+  text-decoration: none;
   width: 100%;
 
   &:hover {
@@ -51,31 +52,20 @@ const RefreshButtonRow = styled.div`
 `;
 
 const FoundryStatsPanel: React.FC = () => {
-  const navigate = useNavigate();
   const { data, loading, error, reload } = useFoundryModuleStats();
-
-  const stopClick = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation();
-  const handleRefresh = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    reload();
-  };
 
   return (
     <Frame style={{ width: '100%', height: '100%' }} title="Foundry Module Installs">
-      <RefreshButtonRow onClick={stopClick}>
+      <RefreshButtonRow>
         <Button
           color={Colors.transparent}
           title={loading ? 'Refreshing…' : 'Refresh'}
-          onClick={handleRefresh}
+          onClick={reload}
           disabled={loading}
           isLoading={loading}
         />
       </RefreshButtonRow>
-      <ClickableArea
-        type="button"
-        onClick={() => navigate(STATS_PATH)}
-        aria-label="View full Foundry module install statistics"
-      >
+      <ClickableArea to={STATS_PATH} aria-label="View full Foundry module install statistics">
         {loading && !data && <StateMessage>Loading…</StateMessage>}
         {error && <RateLimitMessage>Could not load: {error}</RateLimitMessage>}
         {data?.rate_limited && (

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -73,7 +73,7 @@ const FoundryStatsPanel: React.FC = () => {
   }, [getAccessTokenSilently]);
 
   return (
-    <Frame style={{ width: '100%' }} title="Foundry Module Installs">
+    <Frame style={{ width: '100%', height: '100%' }} title="Foundry Module Installs">
       <ClickableArea
         type="button"
         onClick={() => navigate(STATS_PATH)}

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import styled from 'styled-components';
 import Frame from '../../../../components/Frame/Frame';
+import Button from '../../../../components/Button/Button';
+import { Colors } from '../../../../utilities/enums';
 import InstallDonut from './InstallDonut';
 import { FoundryModuleStatsResponse } from '../types';
 
@@ -33,25 +35,38 @@ const HintRow = styled.div`
   text-align: center;
 `;
 
-const Loading = styled.div`
+const StateMessage = styled.div`
   color: ${({ theme }) => theme.colors.textMuted};
   font-style: italic;
-  padding: 1rem;
+  padding: 1.5rem 1rem;
   text-align: center;
+`;
+
+const RateLimitMessage = styled(StateMessage)`
+  color: ${({ theme }) => theme.colors.danger};
+`;
+
+const RefreshButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
 `;
 
 const FoundryStatsPanel: React.FC = () => {
   const { getAccessTokenSilently } = useAuth0();
   const navigate = useNavigate();
   const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
+  const load = useCallback(
+    async (refresh = false) => {
+      setLoading(true);
+      setError(null);
       try {
         const token = await getAccessTokenSilently();
-        const response = await fetch(ENDPOINT, {
+        const url = refresh ? `${ENDPOINT}?refresh=1` : ENDPOINT;
+        const response = await fetch(url, {
           headers: {
             Accept: 'application/json',
             Authorization: `Bearer ${token}`,
@@ -59,34 +74,52 @@ const FoundryStatsPanel: React.FC = () => {
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const json = (await response.json()) as FoundryModuleStatsResponse;
-        if (!cancelled) setData(json);
+        setData(json);
       } catch (e) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : 'Failed to load');
-        }
+        setError(e instanceof Error ? e.message : 'Failed to load');
+      } finally {
+        setLoading(false);
       }
-    };
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [getAccessTokenSilently]);
+    },
+    [getAccessTokenSilently],
+  );
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  const stopClick = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation();
+  const handleRefresh = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void load(true);
+  };
 
   return (
     <Frame style={{ width: '100%', height: '100%' }} title="Foundry Module Installs">
+      <RefreshButtonRow onClick={stopClick}>
+        <Button
+          color={Colors.transparent}
+          title={loading ? 'Refreshing…' : 'Refresh'}
+          onClick={handleRefresh}
+          disabled={loading}
+          isLoading={loading}
+        />
+      </RefreshButtonRow>
       <ClickableArea
         type="button"
         onClick={() => navigate(STATS_PATH)}
         aria-label="View full Foundry module install statistics"
       >
-        {!data && !error && <Loading>Loading…</Loading>}
-        {error && <Loading>Could not load: {error}</Loading>}
-        {data && (
-          <>
-            <InstallDonut modules={data.modules} />
-            <HintRow>Click for full release history →</HintRow>
-          </>
+        {loading && !data && <StateMessage>Loading…</StateMessage>}
+        {error && <RateLimitMessage>Could not load: {error}</RateLimitMessage>}
+        {data?.rate_limited && (
+          <RateLimitMessage>
+            GitHub rate limit reached. Showing partial data — set GITHUB_TOKEN to lift the 60 req/hr
+            cap.
+          </RateLimitMessage>
         )}
+        {data && <InstallDonut modules={data.modules} />}
+        {data && <HintRow>Click for full release history →</HintRow>}
       </ClickableArea>
     </Frame>
   );

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -3,42 +3,34 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import styled from 'styled-components';
 import Frame from '../../../../components/Frame/Frame';
-import DonutSvg from './DonutSvg';
+import InstallDonut from './InstallDonut';
 import { FoundryModuleStatsResponse } from '../types';
 
 const ENDPOINT = '/v1/foundry-module-stats.json';
 const STATS_PATH = '/app/admin-dashboard/foundry-module-stats';
 
 const ClickableArea = styled.button`
-  align-items: center;
   background: transparent;
   border: 0;
   cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: block;
   padding: 0.25rem;
+  text-align: left;
   width: 100%;
 
   &:hover {
-    opacity: 0.85;
+    opacity: 0.92;
   }
 `;
 
-const Total = styled.div`
-  color: ${({ theme }) => theme.colors.primary};
-  font-family: ${({ theme }) => theme.fonts.draconis};
-  font-size: ${({ theme }) => theme.fontSizes.lg};
-  text-align: center;
-`;
-
-const SubLabel = styled.div`
+const HintRow = styled.div`
   color: ${({ theme }) => theme.colors.textMuted};
   font-family: ${({ theme }) => theme.fonts.sansSerif};
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  letter-spacing: 0.1em;
+  font-style: italic;
+  letter-spacing: 0.05em;
+  margin-top: 0.75rem;
   text-align: center;
-  text-transform: uppercase;
 `;
 
 const Loading = styled.div`
@@ -80,10 +72,8 @@ const FoundryStatsPanel: React.FC = () => {
     };
   }, [getAccessTokenSilently]);
 
-  const totalInstalls = data?.modules.reduce((sum, m) => sum + m.latest_installs, 0) ?? 0;
-
   return (
-    <Frame style={{ width: '100%', height: '100%' }} title="Foundry Module Installs">
+    <Frame style={{ width: '100%' }} title="Foundry Module Installs">
       <ClickableArea
         type="button"
         onClick={() => navigate(STATS_PATH)}
@@ -93,9 +83,8 @@ const FoundryStatsPanel: React.FC = () => {
         {error && <Loading>Could not load: {error}</Loading>}
         {data && (
           <>
-            <DonutSvg modules={data.modules} size={160} />
-            <Total>{totalInstalls.toLocaleString()}</Total>
-            <SubLabel>Total installs · click for details</SubLabel>
+            <InstallDonut modules={data.modules} />
+            <HintRow>Click for full release history →</HintRow>
           </>
         )}
       </ClickableArea>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import styled from 'styled-components';
+import Frame from '../../../../components/Frame/Frame';
+import DonutSvg from './DonutSvg';
+import { FoundryModuleStatsResponse } from '../types';
+
+const ENDPOINT = '/v1/foundry-module-stats.json';
+const STATS_PATH = '/app/admin-dashboard/foundry-module-stats';
+
+const ClickableArea = styled.button`
+  align-items: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  width: 100%;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
+const Total = styled.div`
+  color: ${({ theme }) => theme.colors.primary};
+  font-family: ${({ theme }) => theme.fonts.draconis};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  text-align: center;
+`;
+
+const SubLabel = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-family: ${({ theme }) => theme.fonts.sansSerif};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  letter-spacing: 0.1em;
+  text-align: center;
+  text-transform: uppercase;
+`;
+
+const Loading = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+`;
+
+const FoundryStatsPanel: React.FC = () => {
+  const { getAccessTokenSilently } = useAuth0();
+  const navigate = useNavigate();
+  const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const response = await fetch(ENDPOINT, {
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const json = (await response.json()) as FoundryModuleStatsResponse;
+        if (!cancelled) setData(json);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load');
+        }
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessTokenSilently]);
+
+  const totalInstalls = data?.modules.reduce((sum, m) => sum + m.latest_installs, 0) ?? 0;
+
+  return (
+    <Frame style={{ width: '100%', height: '100%' }} title="Foundry Module Installs">
+      <ClickableArea
+        type="button"
+        onClick={() => navigate(STATS_PATH)}
+        aria-label="View full Foundry module install statistics"
+      >
+        {!data && !error && <Loading>Loading…</Loading>}
+        {error && <Loading>Could not load: {error}</Loading>}
+        {data && (
+          <>
+            <DonutSvg modules={data.modules} size={160} />
+            <Total>{totalInstalls.toLocaleString()}</Total>
+            <SubLabel>Total installs · click for details</SubLabel>
+          </>
+        )}
+      </ClickableArea>
+    </Frame>
+  );
+};
+
+export default FoundryStatsPanel;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/FoundryStatsPanel.tsx
@@ -1,14 +1,12 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth0 } from '@auth0/auth0-react';
 import styled from 'styled-components';
 import Frame from '../../../../components/Frame/Frame';
 import Button from '../../../../components/Button/Button';
 import { Colors } from '../../../../utilities/enums';
 import InstallDonut from './InstallDonut';
-import { FoundryModuleStatsResponse } from '../types';
+import useFoundryModuleStats from '../useFoundryModuleStats';
 
-const ENDPOINT = '/v1/foundry-module-stats.json';
 const STATS_PATH = '/app/admin-dashboard/foundry-module-stats';
 
 const ClickableArea = styled.button`
@@ -53,45 +51,13 @@ const RefreshButtonRow = styled.div`
 `;
 
 const FoundryStatsPanel: React.FC = () => {
-  const { getAccessTokenSilently } = useAuth0();
   const navigate = useNavigate();
-  const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(
-    async (refresh = false) => {
-      setLoading(true);
-      setError(null);
-      try {
-        const token = await getAccessTokenSilently();
-        const url = refresh ? `${ENDPOINT}?refresh=1` : ENDPOINT;
-        const response = await fetch(url, {
-          headers: {
-            Accept: 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const json = (await response.json()) as FoundryModuleStatsResponse;
-        setData(json);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to load');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [getAccessTokenSilently],
-  );
-
-  useEffect(() => {
-    void load(false);
-  }, [load]);
+  const { data, loading, error, reload } = useFoundryModuleStats();
 
   const stopClick = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation();
   const handleRefresh = (e: React.MouseEvent) => {
     e.stopPropagation();
-    void load(true);
+    reload();
   };
 
   return (

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/InstallDonut.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/InstallDonut.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ModuleStats } from '../types';
+import DonutSvg, { DONUT_PALETTE } from './DonutSvg';
+import {
+  ChartCanvasWrap,
+  ChartLegend,
+  ChartPlaceholder,
+  ChartWrap,
+  LegendCount,
+  LegendDot,
+  LegendItem,
+  LegendName,
+  LegendPct,
+} from '../FoundryModuleStatsPage.styles';
+
+interface Props {
+  modules: ModuleStats[];
+}
+
+const InstallDonut: React.FC<Props> = ({ modules }) => {
+  const active = modules.filter((m) => m.latest_installs > 0);
+
+  if (active.length === 0) {
+    return (
+      <ChartPlaceholder data-testid="donut-empty">No install data available yet.</ChartPlaceholder>
+    );
+  }
+
+  const total = active.reduce((sum, m) => sum + m.latest_installs, 0);
+
+  return (
+    <ChartWrap>
+      <ChartCanvasWrap>
+        <DonutSvg modules={modules} />
+      </ChartCanvasWrap>
+      <ChartLegend>
+        {active.map((mod, i) => {
+          const pct = ((mod.latest_installs / total) * 100).toFixed(1);
+          return (
+            <LegendItem key={mod.repo}>
+              <LegendDot $color={DONUT_PALETTE[i % DONUT_PALETTE.length]} />
+              <LegendName>{mod.name}</LegendName>
+              <LegendCount>{mod.latest_installs.toLocaleString()}</LegendCount>
+              <LegendPct>{pct}%</LegendPct>
+            </LegendItem>
+          );
+        })}
+      </ChartLegend>
+    </ChartWrap>
+  );
+};
+
+export default InstallDonut;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/ModuleAccordion.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/ModuleAccordion.tsx
@@ -13,8 +13,8 @@ import {
   LatestBadge,
   ModuleCard,
   ModuleHeaderButton,
-  ModuleInfo,
-  ModuleLeft,
+  ModuleHeaderLeft,
+  ModuleHeaderRow,
   ModuleMeta,
   ModuleName,
   NoReleases,
@@ -53,46 +53,42 @@ const VersionColumn: React.FC<{ label: string; info: VersionInfo | null }> = ({ 
 
 const ModuleAccordion: React.FC<Props> = ({ module: mod }) => {
   const [open, setOpen] = useState(false);
-  const stop = (e: React.MouseEvent) => e.stopPropagation();
 
   const maxDl = Math.max(1, ...mod.releases.map((r) => r.installs));
 
   return (
     <ModuleCard $open={open} data-testid={`module-card-${mod.repo}`}>
-      <ModuleHeaderButton type="button" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
-        <ModuleLeft>
-          <Chevron $open={open} aria-hidden="true">
-            ▶
-          </Chevron>
-          <ModuleInfo>
+      <ModuleHeaderRow>
+        <ModuleHeaderLeft>
+          {/* Toggle is a real <button> so it's keyboard-accessible. The repo
+              link and issues badge live as siblings outside the button to
+              avoid nesting <a> inside <button> (invalid HTML). */}
+          <ModuleHeaderButton type="button" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+            <Chevron $open={open} aria-hidden="true">
+              ▶
+            </Chevron>
             <ModuleName>{mod.name}</ModuleName>
-            <ModuleMeta>
-              <RepoLink
-                href={mod.repo_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={stop}
-              >
-                jesshmusic/{mod.repo} ↗
-              </RepoLink>
-              <IssuesBadge
-                href={mod.issues_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={stop}
-                $hasIssues={mod.open_issues_count > 0}
-              >
-                <IssuesDot />
-                {mod.open_issues_count} issue{mod.open_issues_count === 1 ? '' : 's'}
-              </IssuesBadge>
-            </ModuleMeta>
-          </ModuleInfo>
-        </ModuleLeft>
+          </ModuleHeaderButton>
+          <ModuleMeta>
+            <RepoLink href={mod.repo_url} target="_blank" rel="noopener noreferrer">
+              jesshmusic/{mod.repo} ↗
+            </RepoLink>
+            <IssuesBadge
+              href={mod.issues_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              $hasIssues={mod.open_issues_count > 0}
+            >
+              <IssuesDot />
+              {mod.open_issues_count} issue{mod.open_issues_count === 1 ? '' : 's'}
+            </IssuesBadge>
+          </ModuleMeta>
+        </ModuleHeaderLeft>
         <VersionCounts>
           <VersionColumn label="Foundry v13" info={mod.v13} />
           <VersionColumn label="Foundry v14" info={mod.v14} />
         </VersionCounts>
-      </ModuleHeaderButton>
+      </ModuleHeaderRow>
       <AccordionBody $open={open}>
         {mod.error ? (
           <ErrorMsg>Could not load: {mod.error}</ErrorMsg>

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/ModuleAccordion.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/ModuleAccordion.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { ModuleStats, VersionInfo } from '../types';
+import {
+  AccordionBody,
+  Chevron,
+  DlBarBg,
+  DlBarFill,
+  DlBarWrap,
+  DlCount,
+  ErrorMsg,
+  IssuesBadge,
+  IssuesDot,
+  LatestBadge,
+  ModuleCard,
+  ModuleHeaderButton,
+  ModuleInfo,
+  ModuleLeft,
+  ModuleMeta,
+  ModuleName,
+  NoReleases,
+  ReleasesTable,
+  ReleaseTag,
+  RepoLink,
+  VersionCount,
+  VersionCounts,
+  VersionNum,
+  VersionRow,
+  VersionTag,
+} from '../FoundryModuleStatsPage.styles';
+
+interface Props {
+  module: ModuleStats;
+}
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const VersionColumn: React.FC<{ label: string; info: VersionInfo | null }> = ({ label, info }) => (
+  <VersionRow $empty={!info}>
+    <VersionTag>{label}</VersionTag>
+    <VersionNum>{info?.version ?? '—'}</VersionNum>
+    <VersionCount>{info ? info.count.toLocaleString() : '—'}</VersionCount>
+  </VersionRow>
+);
+
+const ModuleAccordion: React.FC<Props> = ({ module: mod }) => {
+  const [open, setOpen] = useState(false);
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  const maxDl = Math.max(1, ...mod.releases.map((r) => r.installs));
+
+  return (
+    <ModuleCard $open={open} data-testid={`module-card-${mod.repo}`}>
+      <ModuleHeaderButton type="button" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+        <ModuleLeft>
+          <Chevron $open={open} aria-hidden="true">
+            ▶
+          </Chevron>
+          <ModuleInfo>
+            <ModuleName>{mod.name}</ModuleName>
+            <ModuleMeta>
+              <RepoLink
+                href={mod.repo_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={stop}
+              >
+                jesshmusic/{mod.repo} ↗
+              </RepoLink>
+              <IssuesBadge
+                href={mod.issues_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={stop}
+                $hasIssues={mod.open_issues_count > 0}
+              >
+                <IssuesDot />
+                {mod.open_issues_count} issue{mod.open_issues_count === 1 ? '' : 's'}
+              </IssuesBadge>
+            </ModuleMeta>
+          </ModuleInfo>
+        </ModuleLeft>
+        <VersionCounts>
+          <VersionColumn label="Foundry v13" info={mod.v13} />
+          <VersionColumn label="Foundry v14" info={mod.v14} />
+        </VersionCounts>
+      </ModuleHeaderButton>
+      <AccordionBody $open={open}>
+        {mod.error ? (
+          <ErrorMsg>Could not load: {mod.error}</ErrorMsg>
+        ) : mod.releases.length === 0 ? (
+          <NoReleases>No releases published yet.</NoReleases>
+        ) : (
+          <ReleasesTable>
+            <thead>
+              <tr>
+                <th>Release</th>
+                <th>Published</th>
+                <th>Installs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mod.releases.map((r, i) => {
+                const pct = Math.round((r.installs / maxDl) * 100);
+                const isLatest = i === 0;
+                return (
+                  <tr key={r.tag} className={isLatest ? 'latest-row' : ''}>
+                    <td>
+                      <ReleaseTag>{r.tag}</ReleaseTag>
+                      {isLatest && <LatestBadge>latest</LatestBadge>}
+                    </td>
+                    <td>{formatDate(r.published_at)}</td>
+                    <td>
+                      <DlBarWrap>
+                        <DlBarBg>
+                          <DlBarFill $pct={pct} />
+                        </DlBarBg>
+                        <DlCount>{r.installs.toLocaleString()}</DlCount>
+                      </DlBarWrap>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </ReleasesTable>
+        )}
+      </AccordionBody>
+    </ModuleCard>
+  );
+};
+
+export default ModuleAccordion;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/SummaryBar.tsx
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/SummaryBar.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ModuleStats } from '../types';
+import {
+  SummaryCard,
+  SummaryGrid,
+  SummaryLabel,
+  SummaryNumber,
+  SummaryNumberSmall,
+} from '../FoundryModuleStatsPage.styles';
+
+interface Props {
+  modules: ModuleStats[];
+}
+
+const SummaryBar: React.FC<Props> = ({ modules }) => {
+  const totalInstalls = modules.reduce((sum, m) => sum + m.latest_installs, 0);
+  const totalReleases = modules.reduce((sum, m) => sum + m.releases.length, 0);
+  const top = [...modules].sort((a, b) => b.latest_installs - a.latest_installs)[0];
+  const topName = top && top.latest_installs > 0 ? top.name : 'None yet';
+
+  return (
+    <SummaryGrid>
+      <SummaryCard>
+        <SummaryNumber>{totalInstalls.toLocaleString()}</SummaryNumber>
+        <SummaryLabel>Total Installs (Latest)</SummaryLabel>
+      </SummaryCard>
+      <SummaryCard>
+        <SummaryNumber>{modules.length}</SummaryNumber>
+        <SummaryLabel>Modules</SummaryLabel>
+      </SummaryCard>
+      <SummaryCard>
+        <SummaryNumber>{totalReleases.toLocaleString()}</SummaryNumber>
+        <SummaryLabel>Releases</SummaryLabel>
+      </SummaryCard>
+      <SummaryCard>
+        <SummaryNumberSmall>{topName}</SummaryNumberSmall>
+        <SummaryLabel>Most Installed</SummaryLabel>
+      </SummaryCard>
+    </SummaryGrid>
+  );
+};
+
+export default SummaryBar;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types.ts
@@ -1,0 +1,31 @@
+export interface VersionInfo {
+  version: string;
+  tag: string;
+  count: number;
+}
+
+export interface ReleaseInfo {
+  tag: string;
+  published_at: string | null;
+  installs: number;
+}
+
+export interface ModuleStats {
+  name: string;
+  repo: string;
+  repo_url: string;
+  issues_url: string;
+  open_issues_count: number;
+  latest_installs: number;
+  total_installs: number;
+  v13: VersionInfo | null;
+  v14: VersionInfo | null;
+  releases: ReleaseInfo[];
+  error: string | null;
+}
+
+export interface FoundryModuleStatsResponse {
+  fetched_at: string;
+  owner: string;
+  modules: ModuleStats[];
+}

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types.ts
@@ -27,5 +27,6 @@ export interface ModuleStats {
 export interface FoundryModuleStatsResponse {
   fetched_at: string;
   owner: string;
+  rate_limited?: boolean;
   modules: ModuleStats[];
 }

--- a/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/useFoundryModuleStats.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/useFoundryModuleStats.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { FoundryModuleStatsResponse } from './types';
+
+const ENDPOINT = '/v1/foundry-module-stats.json';
+
+interface UseFoundryModuleStats {
+  data: FoundryModuleStatsResponse | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+/**
+ * Fetches `/v1/foundry-module-stats.json` with the current Auth0 access
+ * token. Used by both the admin dashboard panel and the full stats page so
+ * the request shape, error handling, and refresh semantics stay in sync.
+ *
+ * `reload()` always passes `?refresh=1` to bypass the Rails cache.
+ */
+const useFoundryModuleStats = (): UseFoundryModuleStats => {
+  const { getAccessTokenSilently } = useAuth0();
+  const [data, setData] = useState<FoundryModuleStatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (refresh: boolean) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = await getAccessTokenSilently();
+        const url = refresh ? `${ENDPOINT}?refresh=1` : ENDPOINT;
+        const response = await fetch(url, {
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const json = (await response.json()) as FoundryModuleStatsResponse;
+        setData(json);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load stats');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [getAccessTokenSilently],
+  );
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  return {
+    data,
+    loading,
+    error,
+    reload: () => {
+      void load(true);
+    },
+  };
+};
+
+export default useFoundryModuleStats;

--- a/app/javascript/bundles/DungeonMasterCampaignManager/store/store.ts
+++ b/app/javascript/bundles/DungeonMasterCampaignManager/store/store.ts
@@ -6,12 +6,6 @@ const store = configureStore({
   reducer: rootReducer,
   preloadedState: {
     flashMessages: [],
-    conditions: {
-      conditions: [],
-      count: 0,
-      currentCondition: null,
-      loading: false,
-    },
     customActions: {
       actions: [],
       count: 0,

--- a/app/policies/foundry_module_stats_policy.rb
+++ b/app/policies/foundry_module_stats_policy.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-FoundryModuleStatsPolicy = Struct.new(:user, :foundry_module_stats) do
-  def initialize(user, record)
-    raise Pundit::NotAuthorizedError, 'must be logged in' unless user
-
-    @user = user
-    @record = record
-  end
-
+class FoundryModuleStatsPolicy < ApplicationPolicy
   def index?
-    @user&.admin?
+    user&.admin?
   end
 end

--- a/app/policies/foundry_module_stats_policy.rb
+++ b/app/policies/foundry_module_stats_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FoundryModuleStatsPolicy = Struct.new(:user, :foundry_module_stats) do
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, 'must be logged in' unless user
+
+    @user = user
+    @record = record
+  end
+
+  def index?
+    @user&.admin?
+  end
+end

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -63,7 +63,7 @@ class FoundryModuleStatsFetcher
       fetched_at: Time.current.iso8601,
       owner: OWNER,
       rate_limited: results.any? { |r| r[:rate_limited] },
-      modules: results.map { |r| r[:module] }
+      modules: results.pluck(:module)
     }
   end
 

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -47,22 +47,23 @@ class FoundryModuleStatsFetcher
   end
 
   def call
-    rate_limited = false
-    modules = Parallel.map(REPOS, in_threads: REPOS.size) do |mod|
-      fetch_module(mod)
+    # Each thread returns its own {module:, rate_limited:} pair so we never
+    # touch shared state inside Parallel.map. The top-level flag is derived
+    # from the results after the parallel work completes.
+    results = Parallel.map(REPOS, in_threads: REPOS.size) do |mod|
+      { module: fetch_module(mod), rate_limited: false }
     rescue RateLimitError => e
-      rate_limited = true
-      error_module(mod, "rate limited: #{e.message}")
+      { module: error_module(mod, "rate limited: #{e.message}"), rate_limited: true }
     rescue StandardError => e
       Rails.logger.warn("FoundryModuleStatsFetcher: #{mod[:repo]} failed — #{e.class}: #{e.message}")
-      error_module(mod, e.message)
+      { module: error_module(mod, e.message), rate_limited: false }
     end
 
     {
       fetched_at: Time.current.iso8601,
       owner: OWNER,
-      rate_limited: rate_limited,
-      modules: modules
+      rate_limited: results.any? { |r| r[:rate_limited] },
+      modules: results.map { |r| r[:module] }
     }
   end
 

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'net/http'
+require 'parallel'
 require 'uri'
 
 # Fetches Foundry VTT module install statistics from GitHub for a hardcoded
@@ -13,11 +14,19 @@ require 'uri'
 # `download_count` field, summed across .zip assets in each release.
 #
 # To bucket the latest installs by Foundry major version (v13 vs v14), we
-# walk releases newest-to-oldest and read each release's `module.json`
-# manifest from raw.githubusercontent.com. The first release we find that
-# targets a given major version (via `compatibility.verified` or
-# `compatibility.minimum`) becomes the "latest for v{major}".
+# walk the most recent releases (capped at MANIFEST_WALK_LIMIT) and read
+# each release's `module.json` manifest from raw.githubusercontent.com. The
+# first release we find that targets a given major version (via
+# `compatibility.verified` or `compatibility.minimum`) becomes the "latest
+# for v{major}".
+#
+# Each repo's GitHub calls run in parallel threads (Net::HTTP releases the
+# GVL during IO so this is a real speedup) and the controller caches the
+# whole result in Rails.cache for an hour to stay well under the 60 req/hr
+# unauthenticated GitHub limit.
 class FoundryModuleStatsFetcher
+  class RateLimitError < StandardError; end
+
   OWNER = 'jesshmusic'
   REPOS = [
     { name: 'Tile Utilities',        repo: 'em-tile-utilities' },
@@ -29,6 +38,7 @@ class FoundryModuleStatsFetcher
     { name: 'Cartography',           repo: 'dorman-lakely-cartography' }
   ].freeze
   WANTED_MAJORS = [13, 14].freeze
+  MANIFEST_WALK_LIMIT = 8
   USER_AGENT = 'dungeon-master-guru-admin'
 
   def initialize(token: ENV.fetch('GITHUB_TOKEN', nil))
@@ -36,10 +46,22 @@ class FoundryModuleStatsFetcher
   end
 
   def call
+    rate_limited = false
+    modules = Parallel.map(REPOS, in_threads: REPOS.size) do |mod|
+      fetch_module(mod)
+    rescue RateLimitError => e
+      rate_limited = true
+      error_module(mod, "rate limited: #{e.message}")
+    rescue StandardError => e
+      Rails.logger.warn("FoundryModuleStatsFetcher: #{mod[:repo]} failed — #{e.class}: #{e.message}")
+      error_module(mod, e.message)
+    end
+
     {
       fetched_at: Time.current.iso8601,
       owner: OWNER,
-      modules: REPOS.map { |mod| fetch_module(mod) }
+      rate_limited: rate_limited,
+      modules: modules
     }
   end
 
@@ -65,8 +87,9 @@ class FoundryModuleStatsFetcher
       releases: releases.map { |r| serialize_release(r) },
       error: nil
     }
-  rescue StandardError => e
-    Rails.logger.warn("FoundryModuleStatsFetcher: #{mod[:repo]} failed — #{e.class}: #{e.message}")
+  end
+
+  def error_module(mod, message)
     {
       name: mod[:name],
       repo: mod[:repo],
@@ -78,7 +101,7 @@ class FoundryModuleStatsFetcher
       v13: nil,
       v14: nil,
       releases: [],
-      error: e.message
+      error: message
     }
   end
 
@@ -112,12 +135,13 @@ class FoundryModuleStatsFetcher
     zip_count(releases.first)
   end
 
-  # Walks releases newest-to-oldest, fetching each release's module.json,
-  # and returns the latest release per Foundry major version we care about.
-  # Stops once all wanted majors are found or releases are exhausted.
+  # Walks the most recent releases newest-to-oldest, fetching each release's
+  # module.json, and returns the latest release per Foundry major version we
+  # care about. Stops once all wanted majors are found, or after walking
+  # MANIFEST_WALK_LIMIT releases — bounding the worst-case API call count.
   def find_latest_per_version(repo, releases)
     results = {}
-    releases.each do |release|
+    releases.first(MANIFEST_WALK_LIMIT).each do |release|
       break if WANTED_MAJORS.all? { |v| results[v] }
 
       manifest = fetch_manifest_for_release(repo, release)
@@ -176,11 +200,32 @@ class FoundryModuleStatsFetcher
       http.request(req)
     end
 
+    if rate_limited?(response)
+      reset = response['x-ratelimit-reset']
+      raise RateLimitError, "GitHub rate limit reached (resets at #{reset_time(reset)})"
+    end
+
     return nil unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
     Rails.logger.warn("FoundryModuleStatsFetcher#fetch_json #{url} -> #{e.class}: #{e.message}")
     nil
+  end
+
+  def rate_limited?(response)
+    return true if response.is_a?(Net::HTTPTooManyRequests)
+    return false unless response.is_a?(Net::HTTPForbidden)
+
+    remaining = response['x-ratelimit-remaining']
+    remaining.present? && remaining.to_i.zero?
+  end
+
+  def reset_time(epoch)
+    return 'unknown' if epoch.blank?
+
+    Time.zone.at(epoch.to_i).strftime('%H:%M %Z')
+  rescue StandardError
+    'unknown'
   end
 end

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'erb'
 require 'json'
 require 'net/http'
 require 'parallel'

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -22,8 +22,9 @@ require 'uri'
 #
 # Each repo's GitHub calls run in parallel threads (Net::HTTP releases the
 # GVL during IO so this is a real speedup) and the controller caches the
-# whole result in Rails.cache for an hour to stay well under the 60 req/hr
-# unauthenticated GitHub limit.
+# whole result in Rails.cache for its configured CACHE_TTL (see
+# Admin::V1::FoundryModuleStatsController::CACHE_TTL) to stay well under
+# the 60 req/hr unauthenticated GitHub limit.
 class FoundryModuleStatsFetcher
   class RateLimitError < StandardError; end
 

--- a/app/services/foundry_module_stats_fetcher.rb
+++ b/app/services/foundry_module_stats_fetcher.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+# Fetches Foundry VTT module install statistics from GitHub for a hardcoded
+# list of repos owned by jesshmusic. Used by the admin Foundry Module Stats
+# page (Admin::V1::FoundryModuleStatsController).
+#
+# Each "module" is a public GitHub repo whose releases are zip packages of a
+# Foundry module. Install counts come from the GitHub release-asset
+# `download_count` field, summed across .zip assets in each release.
+#
+# To bucket the latest installs by Foundry major version (v13 vs v14), we
+# walk releases newest-to-oldest and read each release's `module.json`
+# manifest from raw.githubusercontent.com. The first release we find that
+# targets a given major version (via `compatibility.verified` or
+# `compatibility.minimum`) becomes the "latest for v{major}".
+class FoundryModuleStatsFetcher
+  OWNER = 'jesshmusic'
+  REPOS = [
+    { name: 'Tile Utilities',        repo: 'em-tile-utilities' },
+    { name: 'NPC Generator',         repo: 'dorman-lakelys-npc-generator' },
+    { name: 'CR Calculator',         repo: 'fvtt-challenge-calculator' },
+    { name: 'Crit & Fumble Tables',  repo: 'dorman-lakelys-crit-fumble-tables' },
+    { name: 'Playlist Enhancements', repo: 'dorman-lakelys-playlist-enhancements' },
+    { name: 'Legendary Actions',     repo: 'dormanlakely-legendary-actions' },
+    { name: 'Cartography',           repo: 'dorman-lakely-cartography' }
+  ].freeze
+  WANTED_MAJORS = [13, 14].freeze
+  USER_AGENT = 'dungeon-master-guru-admin'
+
+  def initialize(token: ENV.fetch('GITHUB_TOKEN', nil))
+    @token = token.to_s.strip.presence
+  end
+
+  def call
+    {
+      fetched_at: Time.current.iso8601,
+      owner: OWNER,
+      modules: REPOS.map { |mod| fetch_module(mod) }
+    }
+  end
+
+  private
+
+  def fetch_module(mod)
+    repo = mod[:repo]
+    repo_data = fetch_json("https://api.github.com/repos/#{OWNER}/#{repo}")
+    releases  = fetch_json("https://api.github.com/repos/#{OWNER}/#{repo}/releases") || []
+
+    per_version = find_latest_per_version(repo, releases)
+
+    {
+      name: mod[:name],
+      repo: repo,
+      repo_url: "https://github.com/#{OWNER}/#{repo}",
+      issues_url: "https://github.com/#{OWNER}/#{repo}/issues",
+      open_issues_count: repo_data&.dig('open_issues_count') || 0,
+      latest_installs: latest_installs(releases),
+      total_installs: releases.sum { |r| zip_count(r) },
+      v13: serialize_version(per_version[13]),
+      v14: serialize_version(per_version[14]),
+      releases: releases.map { |r| serialize_release(r) },
+      error: nil
+    }
+  rescue StandardError => e
+    Rails.logger.warn("FoundryModuleStatsFetcher: #{mod[:repo]} failed — #{e.class}: #{e.message}")
+    {
+      name: mod[:name],
+      repo: mod[:repo],
+      repo_url: "https://github.com/#{OWNER}/#{mod[:repo]}",
+      issues_url: "https://github.com/#{OWNER}/#{mod[:repo]}/issues",
+      open_issues_count: 0,
+      latest_installs: 0,
+      total_installs: 0,
+      v13: nil,
+      v14: nil,
+      releases: [],
+      error: e.message
+    }
+  end
+
+  def serialize_release(release)
+    {
+      tag: release['tag_name'],
+      published_at: release['published_at'],
+      installs: zip_count(release)
+    }
+  end
+
+  def serialize_version(info)
+    return nil unless info
+
+    {
+      version: info[:version],
+      tag: info[:tag],
+      count: info[:count]
+    }
+  end
+
+  def zip_count(release)
+    Array(release['assets'])
+      .select { |a| a['name'].to_s.end_with?('.zip') }
+      .sum { |a| a['download_count'].to_i }
+  end
+
+  def latest_installs(releases)
+    return 0 if releases.empty?
+
+    zip_count(releases.first)
+  end
+
+  # Walks releases newest-to-oldest, fetching each release's module.json,
+  # and returns the latest release per Foundry major version we care about.
+  # Stops once all wanted majors are found or releases are exhausted.
+  def find_latest_per_version(repo, releases)
+    results = {}
+    releases.each do |release|
+      break if WANTED_MAJORS.all? { |v| results[v] }
+
+      manifest = fetch_manifest_for_release(repo, release)
+      major = manifest_major_version(manifest)
+      next unless major && WANTED_MAJORS.include?(major) && results[major].nil?
+
+      results[major] = {
+        version: manifest['version'] || release['tag_name'],
+        tag: release['tag_name'],
+        count: zip_count(release)
+      }
+    end
+    results
+  end
+
+  # Fetch the module.json for a given release tag from raw.githubusercontent.com
+  # (the GitHub release-asset URL itself redirects to a host without CORS
+  # headers — not a problem server-side, but raw.githubusercontent.com is
+  # simpler and faster). Tries the tag as-is first, then without a leading "v"
+  # in case the manifest was committed under that variant.
+  def fetch_manifest_for_release(repo, release)
+    tag = release['tag_name'].to_s
+    return nil if tag.empty?
+
+    candidates = [tag]
+    candidates << tag.delete_prefix('v') if tag.start_with?('v')
+
+    candidates.each do |candidate|
+      url = "https://raw.githubusercontent.com/#{OWNER}/#{repo}/#{ERB::Util.url_encode(candidate)}/module.json"
+      manifest = fetch_json(url)
+      return manifest if manifest.is_a?(Hash)
+    end
+    nil
+  end
+
+  def manifest_major_version(manifest)
+    return nil unless manifest.is_a?(Hash)
+
+    compatibility = manifest['compatibility']
+    return nil unless compatibility.is_a?(Hash)
+
+    raw = (compatibility['verified'] || compatibility['minimum']).to_s
+    match = raw.match(/^(\d+)/)
+    match ? match[1].to_i : nil
+  end
+
+  def fetch_json(url)
+    uri = URI(url)
+    req = Net::HTTP::Get.new(uri)
+    req['Accept'] = 'application/vnd.github+json'
+    req['User-Agent'] = USER_AGENT
+    req['Authorization'] = "Bearer #{@token}" if @token
+
+    response = Net::HTTP.start(uri.hostname, uri.port,
+                               use_ssl: true, open_timeout: 5, read_timeout: 15) do |http|
+      http.request(req)
+    end
+
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+    Rails.logger.warn("FoundryModuleStatsFetcher#fetch_json #{url} -> #{e.class}: #{e.message}")
+    nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,10 @@ Rails.application.routes.draw do
       # Admin UI for managing maps
       get '/maps-admin', to: 'foundry_maps_admin#index'
 
+      # Foundry module install statistics (GitHub releases proxy)
+      get '/foundry-module-stats', to: 'foundry_module_stats#index',
+                                   constraints: { format: 'json' }
+
       scope except: %i[new edit] do
         resources :actions, only: %i[index create update destroy], constraints: { format: 'json' }
         resources :proficiencies, only: %i[index show], constraints: { format: 'json' }

--- a/spec/javascript/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.test.tsx
+++ b/spec/javascript/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '../../../test-utils';
+
+const PAGE_PATH =
+  '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/FoundryModuleStatsPage';
+
+jest.mock(
+  '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/containers/PageContainer',
+  () =>
+    function MockPageContainer({ children }: { children: React.ReactNode }) {
+      return <div data-testid="page-container">{children}</div>;
+    },
+);
+
+jest.mock(
+  '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/components/PageTitle/PageTitle',
+  () =>
+    function MockPageTitle({ title }: { title: string }) {
+      return <h1 data-testid="page-title">{title}</h1>;
+    },
+);
+
+jest.mock(
+  '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/components/Frame/Frame',
+  () =>
+    function MockFrame({
+      title,
+      children,
+    }: {
+      title?: string;
+      children: React.ReactNode;
+    }) {
+      return (
+        <div data-testid={`frame-${title ?? 'untitled'}`}>
+          {title && <h2>{title}</h2>}
+          {children}
+        </div>
+      );
+    },
+);
+
+jest.mock('@auth0/auth0-react', () => {
+  // Stable reference — real Auth0 hook also returns the same function across
+  // renders, and our useCallback depends on it.
+  const getAccessTokenSilently = () => Promise.resolve('fake-token');
+  return {
+    useAuth0: () => ({ getAccessTokenSilently }),
+  };
+});
+
+const fixturePayload = {
+  fetched_at: '2026-04-07T12:00:00Z',
+  owner: 'jesshmusic',
+  modules: [
+    {
+      name: 'Tile Utilities',
+      repo: 'em-tile-utilities',
+      repo_url: 'https://github.com/jesshmusic/em-tile-utilities',
+      issues_url: 'https://github.com/jesshmusic/em-tile-utilities/issues',
+      open_issues_count: 0,
+      latest_installs: 100,
+      total_installs: 250,
+      v13: { version: '1.0.0', tag: 'v1.0.0', count: 50 },
+      v14: { version: '2.0.0', tag: 'v2.0.0', count: 100 },
+      releases: [
+        { tag: 'v2.0.0', published_at: '2026-03-01T00:00:00Z', installs: 100 },
+      ],
+      error: null,
+    },
+    {
+      name: 'NPC Generator',
+      repo: 'dorman-lakelys-npc-generator',
+      repo_url: 'https://github.com/jesshmusic/dorman-lakelys-npc-generator',
+      issues_url: 'https://github.com/jesshmusic/dorman-lakelys-npc-generator/issues',
+      open_issues_count: 1,
+      latest_installs: 25,
+      total_installs: 25,
+      v13: null,
+      v14: { version: '0.5.0', tag: 'v0.5.0', count: 25 },
+      releases: [
+        { tag: 'v0.5.0', published_at: '2026-02-01T00:00:00Z', installs: 25 },
+      ],
+      error: null,
+    },
+  ],
+};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const FoundryModuleStatsPage = require(PAGE_PATH).default;
+
+describe('FoundryModuleStatsPage', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fixturePayload),
+      }),
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches stats on mount and renders module names and totals', async () => {
+    render(<FoundryModuleStatsPage />);
+
+    await waitFor(() => {
+      // "Tile Utilities" appears twice (Most Installed card + module header)
+      expect(screen.getAllByText('Tile Utilities').length).toBeGreaterThanOrEqual(1);
+    });
+    // "NPC Generator" appears in both the donut legend and the module header
+    expect(screen.getAllByText('NPC Generator').length).toBeGreaterThanOrEqual(1);
+    // Total installs (latest) summary card: 100 + 25 = 125
+    expect(screen.getByText('125')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/v1/foundry-module-stats.json',
+      expect.any(Object),
+    );
+  });
+
+  it('clicking refresh re-fetches with refresh=1', async () => {
+    render(<FoundryModuleStatsPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText('Tile Utilities').length).toBeGreaterThanOrEqual(1),
+    );
+
+    const refreshBtn = screen.getByRole('button', { name: /refresh/i });
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/v1/foundry-module-stats.json?refresh=1',
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('shows an error message when the request fails', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) }),
+    ) as unknown as typeof fetch;
+
+    render(<FoundryModuleStatsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not load stats: HTTP 500/)).toBeInTheDocument();
+    });
+  });
+});

--- a/spec/javascript/pages/admin-dashboard/foundry-module-stats/InstallDonut.test.tsx
+++ b/spec/javascript/pages/admin-dashboard/foundry-module-stats/InstallDonut.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '../../../test-utils';
+import InstallDonut from '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/InstallDonut';
+import { ModuleStats } from '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types';
+
+const buildModule = (overrides: Partial<ModuleStats> = {}): ModuleStats => ({
+  name: 'Test Module',
+  repo: 'test-module',
+  repo_url: 'https://github.com/jesshmusic/test-module',
+  issues_url: 'https://github.com/jesshmusic/test-module/issues',
+  open_issues_count: 0,
+  latest_installs: 100,
+  total_installs: 200,
+  v13: null,
+  v14: null,
+  releases: [],
+  error: null,
+  ...overrides,
+});
+
+describe('InstallDonut', () => {
+  it('renders an empty placeholder when no modules have installs', () => {
+    render(
+      <InstallDonut
+        modules={[buildModule({ latest_installs: 0 }), buildModule({ latest_installs: 0 })]}
+      />,
+    );
+    expect(screen.getByTestId('donut-empty')).toBeInTheDocument();
+  });
+
+  it('renders one slice and a single legend item when only one module has installs', () => {
+    render(<InstallDonut modules={[buildModule({ latest_installs: 100 })]} />);
+    expect(screen.getAllByTestId('donut-slice')).toHaveLength(1);
+    expect(screen.getByText('Test Module')).toBeInTheDocument();
+    expect(screen.getByText('100.0%')).toBeInTheDocument();
+  });
+
+  it('renders one slice per active module and computes percentages', () => {
+    const modules = [
+      buildModule({ name: 'A', repo: 'a', latest_installs: 75 }),
+      buildModule({ name: 'B', repo: 'b', latest_installs: 25 }),
+      buildModule({ name: 'C', repo: 'c', latest_installs: 0 }), // skipped
+    ];
+    render(<InstallDonut modules={modules} />);
+    expect(screen.getAllByTestId('donut-slice')).toHaveLength(2);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.getByText('75.0%')).toBeInTheDocument();
+    expect(screen.getByText('25.0%')).toBeInTheDocument();
+  });
+});

--- a/spec/javascript/pages/admin-dashboard/foundry-module-stats/ModuleAccordion.test.tsx
+++ b/spec/javascript/pages/admin-dashboard/foundry-module-stats/ModuleAccordion.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent } from '../../../test-utils';
+import ModuleAccordion from '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/components/ModuleAccordion';
+import { ModuleStats } from '../../../../../app/javascript/bundles/DungeonMasterCampaignManager/pages/admin-dashboard/foundry-module-stats/types';
+
+const sampleModule: ModuleStats = {
+  name: 'Tile Utilities',
+  repo: 'em-tile-utilities',
+  repo_url: 'https://github.com/jesshmusic/em-tile-utilities',
+  issues_url: 'https://github.com/jesshmusic/em-tile-utilities/issues',
+  open_issues_count: 3,
+  latest_installs: 50,
+  total_installs: 80,
+  v13: { version: '1.0.0', tag: 'v1.0.0', count: 30 },
+  v14: { version: '2.0.0', tag: 'v2.0.0', count: 50 },
+  releases: [
+    { tag: 'v2.0.0', published_at: '2026-03-01T00:00:00Z', installs: 50 },
+    { tag: 'v1.0.0', published_at: '2025-12-01T00:00:00Z', installs: 30 },
+  ],
+  error: null,
+};
+
+describe('ModuleAccordion', () => {
+  it('renders the module name and version columns by default', () => {
+    render(<ModuleAccordion module={sampleModule} />);
+    expect(screen.getByText('Tile Utilities')).toBeInTheDocument();
+    expect(screen.getByText('Foundry v13')).toBeInTheDocument();
+    expect(screen.getByText('Foundry v14')).toBeInTheDocument();
+    expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    expect(screen.getByText('2.0.0')).toBeInTheDocument();
+  });
+
+  it('shows the open issues count with proper pluralization', () => {
+    render(<ModuleAccordion module={sampleModule} />);
+    expect(screen.getByText('3 issues')).toBeInTheDocument();
+
+    render(<ModuleAccordion module={{ ...sampleModule, open_issues_count: 1 }} />);
+    expect(screen.getByText('1 issue')).toBeInTheDocument();
+  });
+
+  it('expands to show the releases table when the header is clicked', () => {
+    render(<ModuleAccordion module={sampleModule} />);
+    const header = screen.getByRole('button', { expanded: false });
+    fireEvent.click(header);
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+    expect(screen.getByText('Release')).toBeInTheDocument();
+    expect(screen.getByText('latest')).toBeInTheDocument();
+    expect(screen.getByText('v2.0.0')).toBeInTheDocument();
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument();
+  });
+
+  it('shows an error message in the body when the module errored', () => {
+    render(
+      <ModuleAccordion
+        module={{ ...sampleModule, error: 'HTTP 404', releases: [] }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/Could not load: HTTP 404/)).toBeInTheDocument();
+  });
+
+  it('clicking the repo link does not toggle the accordion', () => {
+    render(<ModuleAccordion module={sampleModule} />);
+    const link = screen.getByText(/jesshmusic\/em-tile-utilities/);
+    fireEvent.click(link);
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+});

--- a/spec/requests/admin/v1/foundry_module_stats_spec.rb
+++ b/spec/requests/admin/v1/foundry_module_stats_spec.rb
@@ -29,9 +29,12 @@ RSpec.describe 'Admin::V1::FoundryModuleStats', type: :request do
   end
 
   let(:fetcher) { instance_double(FoundryModuleStatsFetcher, call: fixture_payload) }
+  let(:memory_cache) { ActiveSupport::Cache::MemoryStore.new }
 
   before do
-    Rails.cache.clear
+    # The default test cache is NullStore, which silently no-ops, so the
+    # cache hit/miss assertions below need a real in-memory store.
+    allow(Rails).to receive(:cache).and_return(memory_cache)
     allow(FoundryModuleStatsFetcher).to receive(:new).and_return(fetcher)
   end
 

--- a/spec/requests/admin/v1/foundry_module_stats_spec.rb
+++ b/spec/requests/admin/v1/foundry_module_stats_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+require_relative '../../../../app/services/foundry_module_stats_fetcher'
+
+RSpec.describe 'Admin::V1::FoundryModuleStats', type: :request do
+  let(:fixture_payload) do
+    {
+      fetched_at: '2026-04-07T12:00:00Z',
+      owner: 'jesshmusic',
+      modules: [
+        {
+          name: 'Tile Utilities',
+          repo: 'em-tile-utilities',
+          repo_url: 'https://github.com/jesshmusic/em-tile-utilities',
+          issues_url: 'https://github.com/jesshmusic/em-tile-utilities/issues',
+          open_issues_count: 2,
+          latest_installs: 100,
+          total_installs: 500,
+          v13: { version: '1.2.3', tag: 'v1.2.3', count: 80 },
+          v14: { version: '2.0.0', tag: 'v2.0.0', count: 20 },
+          releases: [
+            { tag: 'v2.0.0', published_at: '2026-03-01T00:00:00Z', installs: 20 },
+            { tag: 'v1.2.3', published_at: '2025-12-01T00:00:00Z', installs: 80 }
+          ],
+          error: nil
+        }
+      ]
+    }
+  end
+
+  let(:fetcher) { instance_double(FoundryModuleStatsFetcher, call: fixture_payload) }
+
+  before do
+    Rails.cache.clear
+    allow(FoundryModuleStatsFetcher).to receive(:new).and_return(fetcher)
+  end
+
+  describe 'GET /v1/foundry-module-stats' do
+    context 'when user is an admin' do
+      let(:admin) { create(:admin_user) }
+
+      before { stub_authentication(admin) }
+
+      it 'returns 200' do
+        get '/v1/foundry-module-stats', as: :json
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns the fetcher payload as JSON' do
+        get '/v1/foundry-module-stats', as: :json
+        body = JSON.parse(response.body)
+        expect(body['owner']).to eq('jesshmusic')
+        expect(body['modules'].first['name']).to eq('Tile Utilities')
+        expect(body['modules'].first['v13']['version']).to eq('1.2.3')
+      end
+
+      it 'caches the response across requests' do
+        get '/v1/foundry-module-stats', as: :json
+        get '/v1/foundry-module-stats', as: :json
+        expect(FoundryModuleStatsFetcher).to have_received(:new).once
+      end
+
+      it 'busts the cache when refresh=1 is passed' do
+        get '/v1/foundry-module-stats', as: :json
+        get '/v1/foundry-module-stats', params: { refresh: 1 }, as: :json
+        expect(FoundryModuleStatsFetcher).to have_received(:new).twice
+      end
+    end
+
+    context 'when user is not an admin' do
+      let(:user) { create(:user) }
+
+      before { stub_authentication(user) }
+
+      it 'returns forbidden' do
+        get '/v1/foundry-module-stats', as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'does not call the fetcher' do
+        get '/v1/foundry-module-stats', as: :json
+        expect(FoundryModuleStatsFetcher).not_to have_received(:new)
+      end
+    end
+
+    context 'when the user is not authenticated' do
+      before { stub_no_auth }
+
+      it 'returns forbidden or unauthorized' do
+        get '/v1/foundry-module-stats', as: :json
+        expect(response).to have_http_status(:forbidden).or have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/services/foundry_module_stats_fetcher_spec.rb
+++ b/spec/services/foundry_module_stats_fetcher_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+require_relative '../../app/services/foundry_module_stats_fetcher'
+
+RSpec.describe FoundryModuleStatsFetcher do
+  subject(:fetcher) { described_class.new(token: nil) }
+
+  # Stub the private fetch_json method so we don't hit the network. Each
+  # URL maps to a canned response (or nil for "not found").
+  def stub_http(url_to_response)
+    allow(fetcher).to receive(:fetch_json) do |url|
+      url_to_response.fetch(url, nil)
+    end
+  end
+
+  describe '#call' do
+    it 'returns owner, fetched_at, and a module entry per repo' do
+      allow(fetcher).to receive(:fetch_json).and_return(nil)
+      result = fetcher.call
+
+      expect(result[:owner]).to eq('jesshmusic')
+      expect(result[:fetched_at]).to be_a(String)
+      expect(result[:modules].length).to eq(described_class::REPOS.length)
+    end
+
+    it 'aggregates install counts and buckets the latest releases by Foundry version' do
+      repo_url = 'https://api.github.com/repos/jesshmusic/em-tile-utilities'
+      releases_url = "#{repo_url}/releases"
+
+      releases = [
+        {
+          'tag_name' => 'v2.1.0',
+          'published_at' => '2026-03-01T00:00:00Z',
+          'assets' => [
+            { 'name' => 'em-tile-utilities.zip', 'download_count' => 50 },
+            { 'name' => 'module.json', 'download_count' => 999 } # ignored, not a zip
+          ]
+        },
+        {
+          'tag_name' => 'v1.5.0',
+          'published_at' => '2025-12-01T00:00:00Z',
+          'assets' => [
+            { 'name' => 'em-tile-utilities.zip', 'download_count' => 30 }
+          ]
+        }
+      ]
+
+      url_map = {
+        repo_url => { 'open_issues_count' => 4 },
+        releases_url => releases,
+        'https://raw.githubusercontent.com/jesshmusic/em-tile-utilities/v2.1.0/module.json' =>
+          { 'version' => '2.1.0', 'compatibility' => { 'verified' => '14' } },
+        'https://raw.githubusercontent.com/jesshmusic/em-tile-utilities/v1.5.0/module.json' =>
+          { 'version' => '1.5.0', 'compatibility' => { 'verified' => '13' } }
+      }
+
+      # All other repos return nil so they're built as empty/error rows.
+      allow(fetcher).to receive(:fetch_json) { |url| url_map[url] }
+
+      result = fetcher.call
+      tile = result[:modules].find { |m| m[:repo] == 'em-tile-utilities' }
+
+      expect(tile[:open_issues_count]).to eq(4)
+      expect(tile[:latest_installs]).to eq(50)
+      expect(tile[:total_installs]).to eq(80)
+      expect(tile[:v13]).to eq(version: '1.5.0', tag: 'v1.5.0', count: 30)
+      expect(tile[:v14]).to eq(version: '2.1.0', tag: 'v2.1.0', count: 50)
+      expect(tile[:releases].map { |r| r[:tag] }).to eq(%w[v2.1.0 v1.5.0])
+      expect(tile[:error]).to be_nil
+    end
+
+    it 'falls back from compatibility.verified to compatibility.minimum for version detection' do
+      repo_url = 'https://api.github.com/repos/jesshmusic/em-tile-utilities'
+      releases = [
+        { 'tag_name' => 'v1.0.0', 'published_at' => '2025-01-01T00:00:00Z',
+          'assets' => [{ 'name' => 'mod.zip', 'download_count' => 10 }] }
+      ]
+      url_map = {
+        repo_url => { 'open_issues_count' => 0 },
+        "#{repo_url}/releases" => releases,
+        'https://raw.githubusercontent.com/jesshmusic/em-tile-utilities/v1.0.0/module.json' =>
+          { 'version' => '1.0.0', 'compatibility' => { 'minimum' => '13.0.0' } }
+      }
+      allow(fetcher).to receive(:fetch_json) { |url| url_map[url] }
+
+      result = fetcher.call
+      tile = result[:modules].find { |m| m[:repo] == 'em-tile-utilities' }
+      expect(tile[:v13]).to include(version: '1.0.0', count: 10)
+    end
+
+    it 'returns an error entry for a repo that raises during fetch' do
+      allow(fetcher).to receive(:fetch_json).and_raise(StandardError.new('boom'))
+
+      result = fetcher.call
+      first = result[:modules].first
+      expect(first[:error]).to eq('boom')
+      expect(first[:latest_installs]).to eq(0)
+      expect(first[:releases]).to eq([])
+    end
+  end
+end

--- a/spec/services/foundry_module_stats_fetcher_spec.rb
+++ b/spec/services/foundry_module_stats_fetcher_spec.rb
@@ -14,13 +14,24 @@ RSpec.describe FoundryModuleStatsFetcher do
   end
 
   describe '#call' do
-    it 'returns owner, fetched_at, and a module entry per repo' do
+    it 'returns owner, fetched_at, rate_limited, and a module entry per repo' do
       allow(fetcher).to receive(:fetch_json).and_return(nil)
       result = fetcher.call
 
       expect(result[:owner]).to eq('jesshmusic')
       expect(result[:fetched_at]).to be_a(String)
+      expect(result[:rate_limited]).to be(false)
       expect(result[:modules].length).to eq(described_class::REPOS.length)
+    end
+
+    it 'flags rate_limited when any repo fetch hits the GitHub limit' do
+      allow(fetcher)
+        .to receive(:fetch_json)
+        .and_raise(FoundryModuleStatsFetcher::RateLimitError.new('quota exhausted'))
+
+      result = fetcher.call
+      expect(result[:rate_limited]).to be(true)
+      expect(result[:modules]).to all(include(error: a_string_matching(/rate limited/)))
     end
 
     it 'aggregates install counts and buckets the latest releases by Foundry version' do

--- a/spec/services/foundry_module_stats_fetcher_spec.rb
+++ b/spec/services/foundry_module_stats_fetcher_spec.rb
@@ -5,14 +5,6 @@ require_relative '../../app/services/foundry_module_stats_fetcher'
 RSpec.describe FoundryModuleStatsFetcher do
   subject(:fetcher) { described_class.new(token: nil) }
 
-  # Stub the private fetch_json method so we don't hit the network. Each
-  # URL maps to a canned response (or nil for "not found").
-  def stub_http(url_to_response)
-    allow(fetcher).to receive(:fetch_json) do |url|
-      url_to_response.fetch(url, nil)
-    end
-  end
-
   describe '#call' do
     it 'returns owner, fetched_at, rate_limited, and a module entry per repo' do
       allow(fetcher).to receive(:fetch_json).and_return(nil)
@@ -65,7 +57,8 @@ RSpec.describe FoundryModuleStatsFetcher do
           { 'version' => '1.5.0', 'compatibility' => { 'verified' => '13' } }
       }
 
-      # All other repos return nil so they're built as empty/error rows.
+      # All other repos return nil for every call, so they're built as
+      # empty (non-error) rows with zeroed counts and no releases.
       allow(fetcher).to receive(:fetch_json) { |url| url_map[url] }
 
       result = fetcher.call


### PR DESCRIPTION
## Summary
- New admin page at `/app/admin-dashboard/foundry-module-stats` showing GitHub install statistics for the seven `jesshmusic` Foundry VTT modules: total installs (latest release), per-module v13/v14 install counts, full release history with download counts, and an install-distribution donut with hover tooltips.
- Rails proxy endpoint `GET /v1/foundry-module-stats.json` (admin-only via Pundit + `SecuredController`) — fetches from GitHub server-side, walks each release's `module.json` (capped at 8) to bucket installs by Foundry major version, parallelizes the 7 repo fetches with `Parallel.map`, caches in `Rails.cache` for 15 minutes, and accepts `?refresh=1` to bust the cache. Detects rate-limit responses (429 / 403+remaining=0) and surfaces a `rate_limited` flag without poisoning the cache.
- Clickable donut + legend panel on the main admin dashboard (`flex: 2`) sitting next to the existing Info panel (`flex: 1`) at equal height, with its own Refresh button. Click to navigate to the full stats page.
- Rate-limit warning shown clearly on both the panel and the full page when GitHub throttles us.
- Site version moved from the admin dashboard's "Site" frame into the footer, alongside a new bottom-line copyright row reading "© <year> Jess Hendricks · v<version>".

## Incidental fixes
- **Logout fragility**: `SideBar.handleLogout` used to gate Auth0's `logout()` call on `getAccessTokenSilently()` succeeding, so a stale refresh token would silently swallow the entire logout. The token call now lives in a `.then` and `logout()` always fires from a `.finally`.
- **Redux warning**: removed the obsolete `conditions` key from `store.ts` `preloadedState` (matching reducer was deleted long ago, triggering a runtime warning on every page load).
- **DataTable key warning**: header rows used `headerGroup.id`, which is `undefined` in react-table v7, so React was rendering them keyless. Switched to the destructured key from `getHeaderGroupProps()` with an indexed fallback.

## Heroku config
- `GITHUB_TOKEN` is now set on Heroku via `heroku config:set` (release v198) — lifts the GitHub rate limit from 60 to 5000 req/hr. The fetcher works without it too, just rate-limited.

## Test plan
- [x] `NO_COVERAGE=true yarn test` — 1352 / 1353 passing (1 pre-existing skip)
- [x] `yarn lint`
- [x] `yarn format:check`
- [ ] `NO_COVERAGE=true bundle exec rspec spec/services/foundry_module_stats_fetcher_spec.rb spec/requests/admin/v1/foundry_module_stats_spec.rb` (couldn't run locally — `pg 1.5.9` won't compile against the new clang in my shell, CI will validate)
- [ ] `bundle exec rubocop` (same blocker)
- [ ] Sign in as admin → admin dashboard donut renders with hover tooltips → click donut → full stats page loads → expand a module accordion → release table renders → click Refresh and confirm `?refresh=1` query param fires
- [ ] Sign in as non-admin → `/app/admin-dashboard/foundry-module-stats` redirects to `/`
- [ ] Click Logout — confirm session ends cleanly even with a stale refresh token

🤖 Generated with [Claude Code](https://claude.com/claude-code)